### PR TITLE
Add a try/except block to handle connector errors

### DIFF
--- a/scm_staging/rabbit_listener.py
+++ b/scm_staging/rabbit_listener.py
@@ -4,6 +4,7 @@ from typing import TypedDict
 from pika.adapters.blocking_connection import BlockingChannel
 from pika.exchange_type import ExchangeType
 from pika.spec import Basic
+import pika.exceptions
 
 from py_gitea_opensuse_org.api.repository_api import RepositoryApi
 from py_gitea_opensuse_org.models.pull_request import PullRequest
@@ -83,27 +84,13 @@ import pika
 
 def main() -> None:
     loop = asyncio.get_event_loop()
-    connection = pika.BlockingConnection(
-        pika.URLParameters("amqps://opensuse:opensuse@rabbit.opensuse.org")
-    )
-    channel = connection.channel()
-
-    channel.exchange_declare(
-        exchange="pubsub", exchange_type=ExchangeType.topic, passive=True, durable=True
-    )
-
-    result = channel.queue_declare("", exclusive=True)
-    queue_name = result.method.queue
-    assert queue_name
-
-    channel.queue_bind(exchange="pubsub", queue=queue_name, routing_key="#")
 
     def callback(
         ch: BlockingChannel,
         method: Basic.Deliver,
         properties: pika.BasicProperties,
         body: bytes,
-    ):
+    ) -> None:
         if (method.routing_key or "") not in (
             f"{_PREFIX}.package.build_success",
             f"{_PREFIX}.package.build_fail",
@@ -125,6 +112,42 @@ def main() -> None:
         except Exception:
             pass
 
-    channel.basic_consume(queue_name, callback, auto_ack=True)
+    while True:
+        try:
+            connection = pika.BlockingConnection(
+                pika.URLParameters("amqps://opensuse:opensuse@rabbit.opensuse.org")
+            )
+            channel = connection.channel()
 
-    channel.start_consuming()
+            channel.exchange_declare(
+                exchange="pubsub",
+                exchange_type=ExchangeType.topic,
+                passive=True,
+                durable=True,
+            )
+
+            result = channel.queue_declare("", exclusive=True)
+            queue_name = result.method.queue
+            assert queue_name
+
+            channel.queue_bind(exchange="pubsub", queue=queue_name, routing_key="#")
+
+            channel.basic_consume(queue_name, callback, auto_ack=True)
+
+            channel.start_consuming()
+
+        except pika.exceptions.ConnectionClosedByBroker:
+            # Uncomment this to make the example not attempt recovery
+            # from server-initiated connection closure, including
+            # when the node is stopped cleanly
+            #
+            # break
+            continue
+        # Do not recover on channel errors
+        except pika.exceptions.AMQPChannelError as err:
+            print("Caught a channel error: {}, stopping...".format(err))
+            break
+        # Recover on all other connection errors
+        except pika.exceptions.AMQPConnectionError:
+            print("Connection was closed, retrying...")
+            continue


### PR DESCRIPTION
Taken from https://pika.readthedocs.io/en/stable/examples/blocking_consume_recover_multiple_hosts.html