### PR TITLE
Refactor logging: Move make_logger into subclass of logging.Logger

### DIFF
--- a/scm_staging/logger.py
+++ b/scm_staging/logger.py
@@ -1,4 +1,5 @@
 import logging
+from typing import cast
 
 # logging for tornado access
 from tornado.log import access_log
@@ -13,48 +14,50 @@ from tornado.log import gen_log
 from tornado.log import LogFormatter
 
 
-LOGGER = logging.getLogger(__name__)
+class AppLogger(logging.Logger):
+    def configure_log_files(
+        self,
+        root_log_file: str | None = None,
+        access_log_file: str | None = None,
+        app_log_file: str | None = None,
+        general_log_file: str | None = None,
+    ) -> None:
+        root_format = "%(color)s[%(asctime)s::%(name)s %(levelname)s] %(filename)s:\
+                %(lineno)d in %(funcName)s %(end_color)s\n %(message)s\n"
+        datetime_format = "%Y-%m-%d %H:%M:%S"
+        self.root_formatter = LogFormatter(
+            fmt=root_format, datefmt=datetime_format, color=True
+        )
+        self.access = access_log
+        self.app = app_log
+        self.general = gen_log
+
+        # the following lines need to be called after options.parse_command_line or else empty
+        if access_log_file:
+            handler = logging.FileHandler(access_log_file)
+            handler.setFormatter(self.root_formatter)
+            self.access.addHandler(handler)
+
+        if app_log_file:
+            handler = logging.FileHandler(app_log_file)
+            handler.setFormatter(self.root_formatter)
+            self.app.addHandler(handler)
+
+        if general_log_file:
+            handler = logging.FileHandler(general_log_file)
+            handler.setFormatter(self.root_formatter)
+            self.general.addHandler(handler)
+
+        if root_log_file:
+            handler = logging.FileHandler(root_log_file)
+            handler.setFormatter(self.root_formatter)
+            self.root.addHandler(handler)
+        else:
+            if not self.root.handlers:
+                self.root.addHandler(logging.StreamHandler())
+            self.root.handlers[0].setFormatter(self.root_formatter)
 
 
-def make_logger(
-    root_log_file=None,
-    access_log_file=None,
-    app_log_file=None,
-    general_log_file=None,
-):
-    """all log going to standard if not define file for it."""
-
-    root_format = "%(color)s[%(asctime)s::%(name)s %(levelname)s] %(filename)s:\
-            %(lineno)d in %(funcName)s %(end_color)s\n %(message)s\n"
-    datetime_format = "%Y-%m-%d %H:%M:%S"
-    LOGGER.root_formatter = LogFormatter(
-        fmt=root_format, datefmt=datetime_format, color=True
-    )
-    LOGGER.access = access_log
-    LOGGER.app = app_log
-    LOGGER.general = gen_log
-    # the following lines need to be called after options.parse_command_line or else empty
-    if access_log_file:
-        handler = logging.FileHandler(access_log_file)
-        handler.setFormatter(LOGGER.root_formatter)
-        LOGGER.access.addHandle(handler)
-
-    if app_log_file:
-        handler = logging.FileHandler(app_log_file)
-        handler.setFormatter(LOGGER.root_formatter)
-        LOGGER.app.addHandle(handler)
-
-    if general_log_file:
-        handler = logging.FileHandler(general_log_file)
-        handler.setFormatter(LOGGER.root_formatter)
-        LOGGER.general.addHandle(handler)
-
-    if root_log_file:
-        handler = logging.FileHandler(root_log_file)
-        handler.setFormatter(LOGGER.root_formatter)
-        LOGGER.root.addHandle(handler)
-    else:
-        LOGGER.root.handlers[0].setFormatter(LOGGER.root_formatter)
-
-
-LOGGER.make_logger = make_logger
+logging.setLoggerClass(AppLogger)
+LOGGER: AppLogger = cast(AppLogger, logging.getLogger(__name__))
+LOGGER.setLevel(logging.DEBUG)

--- a/scm_staging/rabbit_listener.py
+++ b/scm_staging/rabbit_listener.py
@@ -265,5 +265,6 @@ def main() -> None:
     args = parser.parse_args()
     db_file = args.db_file[0]
 
+    LOGGER.configure_log_files()
     create_db(db_file)
     rabbit_listener(db_file)

--- a/scm_staging/webhook.py
+++ b/scm_staging/webhook.py
@@ -440,7 +440,7 @@ def make_app(app_config: AppConfig) -> Application:
 
 
 """
-Tornado options and define from command line e.g. --port 8000 
+Tornado options and define from command line e.g. --port 8000
 """
 define("port", default=8000, help="Tornado web service port listen on")
 define("log", default=None, help="Filename for scm_staging log, default to console")
@@ -463,7 +463,7 @@ define(
 
 def main():
     options.parse_command_line()
-    LOGGER.make_logger(
+    LOGGER.configure_log_files(
         options.log, options.access_log, options.app_log, options.general_log
     )
     app_config = AppConfig.from_env()


### PR DESCRIPTION
This ensures that type checkers do not get confused